### PR TITLE
Add Atomic Heart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Python script to extract/backup savefiles out of Xbox Game Pass for PC games.
 - **Hades** *(not tested with the Steam/Epic version, but the save format should be the same)*
 - **Control** *(confirmed working with the Epic version, save format should be the same with Steam)*
 - **Final Fantasy XV** *(confirmed working with the Steam version)*
+- **Atomic Heart** *(confirmed working with the Steam version, at least when all fiels where copied before ever launching Steam version)*
 
 ## Running
 Run `main.py` with Python 3+. The script produces ZIP files for each of the supported games that are installed for the current user.

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ supported_xgp_apps = {
     "Just Cause 4": "39C668CD.JustCause4-BaseGame_r7bfsmp40f67j",
     "Hades": "SupergiantGamesLLC.Hades_q53c1yqmx7pha",
     "Control": "505GAMESS.P.A.ControlPCGP_tefn33qh9azfc",
+    "Atomic Heart": "FocusHomeInteractiveSA.579645D26CFD_4hny5m903y3g0",
     "Final Fantasy XV": "39EA002F.FINALFANTASYXVforPC_n746a19ndrrjg"
 }
 
@@ -125,7 +126,7 @@ def read_containers(pkg_name):
 def get_save_paths(store_pkg_name, containers, temp_dir):
     save_meta = []
 
-    if store_pkg_name in [supported_xgp_apps["Yakuza 0"], supported_xgp_apps["Yakuza Like a Dragon"], supported_xgp_apps["Final Fantasy XV"]]:
+    if store_pkg_name in [supported_xgp_apps["Yakuza 0"], supported_xgp_apps["Yakuza Like a Dragon"], supported_xgp_apps["Final Fantasy XV"], supported_xgp_apps["Atomic Heart"]]:
         # Handle Yakuza 0, Yakuza Like a Dragon and Final Fantasy XV saves
         # Yakuza 0 uses containers in a "1 container, 1 file" manner (1c1f),
         # where the container includes a file named "data" that is the file named as the container.

--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ def read_containers(pkg_name):
 def get_save_paths(store_pkg_name, containers, temp_dir):
     save_meta = []
 
-    if store_pkg_name in [supported_xgp_apps["Yakuza 0"], supported_xgp_apps["Yakuza Like a Dragon"], supported_xgp_apps["Final Fantasy XV"], supported_xgp_apps["Atomic Heart"]]:
+    if store_pkg_name in [supported_xgp_apps["Yakuza 0"], supported_xgp_apps["Yakuza Like a Dragon"], supported_xgp_apps["Final Fantasy XV"]]:
         # Handle Yakuza 0, Yakuza Like a Dragon and Final Fantasy XV saves
         # Yakuza 0 uses containers in a "1 container, 1 file" manner (1c1f),
         # where the container includes a file named "data" that is the file named as the container.
@@ -162,6 +162,15 @@ def get_save_paths(store_pkg_name, containers, temp_dir):
 
             for file in container["files"]:
                 save_meta.append((path / f"{file['name']}.chunk", file['path']))
+                
+    elif store_pkg_name in [supported_xgp_apps["Atomic Heart"]]:
+        # Handle Atomic Heart saves
+        # Atomic Heart uses containers in a "1 container, 1 file" manner (1c1f),
+        # where the container includes a file named "data" that is the file named as the container. All files need to have ".sav" added as an extension
+        for container in containers:
+            fname = container["name"] + '.sav'
+            fpath = container["files"][0]["path"]
+            save_meta.append((fname, fpath))
 
     else:
         raise Exception("Unsupported XGP app \"%s\"" % store_pkg_name)


### PR DESCRIPTION
You must also add ".sav" extension to all extracted files. Worked for me, though I copied all files (so including SavedSettings.sav) and did so before ever launching Steam version. 

From what I've read on Reddit, it didn't work for people who copied just save files and did so after launching the game for the first time (saves showed up in game, but game was stuck on loading screen when trying to use them).