### PR TITLE
Remove Yakuza: Like A Dragon

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Legend: ✅ Confirmed working, ❔ Unconfirmed, - Not available in the store
 | Totally Accurate Battle Simulator | ✅ | - |
 | Wo Long: Fallen Dynasty | ❔ | - |
 | Yakuza 0 | ✅ | - |
-| Yakuza: Like a Dragon | ❔ | - |
 
 ## Incompatible games
 These games use different save formats than the Steam/Epic version that can't be easily converted.
@@ -55,6 +54,7 @@ These games use different save formats than the Steam/Epic version that can't be
 | Death's Door | [#79](https://github.com/Z1ni/XGP-save-extractor/issues/79) |
 | Forza Horizon 4 | [#71](https://github.com/Z1ni/XGP-save-extractor/issues/71) |
 | Tinykin | [#28](https://github.com/Z1ni/XGP-save-extractor/issues/28) |
+| Yakuza: Like a Dragon | [#72](https://github.com/Z1ni/XGP-save-extractor/issues/72) |
 
 ### Possibly incompatible (needs testing)
 Please test these and report back to the issue if the extracted saves work or not.


### PR DESCRIPTION
Save files from MS Store version are seen as corrupted by the Steam version. From what I've search around the web nobody knows how to make them work.