### PR TITLE
Yakuza Kiwami Support

### DIFF
--- a/games.json
+++ b/games.json
@@ -82,6 +82,11 @@
             "package": "SEGAofAmericaInc.Yakuza0PC_s751p9cej88mt",
             "handler": "1c1f"
         },
+        {
+            "name": "Yakuza Kiwami",
+            "package": "SEGAofAmericaInc.YakuzaKiwamiPC_s751p9cej88mt",
+            "handler": "1c1f"
+        },
         // 1cnf
         // 1 container, n files
         // One container contains all save files.


### PR DESCRIPTION
Added Yakuza Kiwami support by adding game to games.json. This works the same way as Yakuza 0 with no trouble. Please note: this was tested with the GOG version of the game (Yakuza 0 and Yakuza Kiwami), not Steam. This should add support for Steam as well. Source: https://www.gog.com/forum/yakuza_series/converting_saves_from_steam