### PR TITLE
Add support for Quantum Break

### DIFF
--- a/games.json
+++ b/games.json
@@ -163,6 +163,11 @@
             "package": "946B6A6E.WoLongFallenDynasty_dkffhzhmh6pmy",
             "handler": "1cnf-folder"
         },
+        {
+            "name": "Quantum Break",
+            "package": "Microsoft.QuantumBreak_8wekyb3d8bbwe",
+            "handler": "1cnf-folder"
+        },
         // Yakuza / Like a Dragon games
         // Saves contain icons and the file names may be wrong
         {


### PR DESCRIPTION
this seems to work. i wasn't sure if this was the right option for this game but it gave me a folder with a save file I was able to move to the steam version. 
Not sure what the config/preferences file is about, i couldn't find an equivalent in the steam folder. 