### PR TITLE
support for oblivion remastered

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Legend: ✅ Confirmed working, ❔ Unconfirmed, - Not available in the store
 | Manor Lords | ✅ | ❔ |
 | Monster Train | ✅ | - |
 | Ninja Gaiden Sigma | ✅ | - |
+| Oblivion Remastered | ✅ | ❔ |
 | Octopath Traveller | ❔ | ❔ |
 | Palworld | ✅ | - |
 | Persona 5 Royal | ✅ | - |

--- a/games.json
+++ b/games.json
@@ -248,6 +248,12 @@
             "name": "Cricket 24",
             "package": "BigbenInteractiveSA.Cricket24Win10_tqjv3vrxr8ppw",
             "handler": "cricket-24"
+        },
+        // Oblivion Remastered
+        {
+            "name": "Oblivion Remastered",
+            "package": "BethesdaSoftworks.ProjectAltar_3275kfvn8vcwc",
+            "handler": "oblivion"
         }
     ]
 }

--- a/games.json
+++ b/games.json
@@ -253,7 +253,10 @@
         {
             "name": "Oblivion Remastered",
             "package": "BethesdaSoftworks.ProjectAltar_3275kfvn8vcwc",
-            "handler": "oblivion"
+            "handler": "1c1f",
+            "handler_args": {
+                "suffix": ".sav"
+            }
         }
     ]
 }

--- a/main.py
+++ b/main.py
@@ -448,6 +448,13 @@ def get_save_paths(
                 fname = f"{container['name']}.{file['name']}"
                 save_meta.append((fname, file["path"]))
 
+    elif handler_name == "oblivion":
+        # Container name is the filename prefix, file names inside container are appended to that after "."
+        for container in containers:
+            for file in container["files"]:
+                fname = f"{container['name']}.sav"
+                save_meta.append((fname, file["path"]))
+
     elif handler_name == "arcade-paradise":
         # Arcade Paradise seems to save to one container with one file, which should be renamed to "RATSaveData.dat" for Steam
         fpath = containers[0]["files"][0]["path"]

--- a/main.py
+++ b/main.py
@@ -448,13 +448,6 @@ def get_save_paths(
                 fname = f"{container['name']}.{file['name']}"
                 save_meta.append((fname, file["path"]))
 
-    elif handler_name == "oblivion":
-        # Container name is the filename prefix, file names inside container are appended to that after "."
-        for container in containers:
-            for file in container["files"]:
-                fname = f"{container['name']}.sav"
-                save_meta.append((fname, file["path"]))
-
     elif handler_name == "arcade-paradise":
         # Arcade Paradise seems to save to one container with one file, which should be renamed to "RATSaveData.dat" for Steam
         fpath = containers[0]["files"][0]["path"]


### PR DESCRIPTION
This enables XGP saves of oblivion remastered to be output so that you can use it in versions / releases of the title.
It copies the forza handler, but instead of .data it uses .sav as expected.

It updates the games.json accordingly too.
tested and was able to play using the converted files.