### PR TITLE
add support for Clair Obscur: Expedition 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Legend: ✅ Confirmed working, ❔ Unconfirmed, - Not available in the store
 | Chorus | ✅ | ❔ |
 | Control | ❔ | ✅ |
 | Coral Island | ✅ | - |
+| Clair Obscur: Expedition 33 | ✅ | - |
 | Cricket 24 | ✅ | - |
 | Final Fantasy XV | ✅ | - |
 | Forza Horizon 5 | ✅ | - |

--- a/games.json
+++ b/games.json
@@ -257,6 +257,12 @@
             "handler_args": {
                 "suffix": ".sav"
             }
+        },
+        // Clair Obscur: Expedition 33
+        {
+            "name": "Clair Obscur: Expedition 33",
+            "package": "KeplerInteractive.Expedition33_ymj30pw7xe604",
+            "handler": "coral-island"
         }
     ]
 }


### PR DESCRIPTION
This enables XGP saves for Clair Obscur: Expedition 33
coral-island is used since it uses the same BACKUP folder structure


tested and was able to play using the converted files