### PR TITLE
Add support for One Lonely Outpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Legend: ✅ Confirmed working, ❔ Unconfirmed, - Not available in the store
 | Ninja Gaiden Sigma | ✅ | - |
 | Oblivion Remastered | ✅ | ❔ |
 | Octopath Traveller | ❔ | ❔ |
+| One Lonely Outpost | ✅ | ❔ |
 | Palworld | ✅ | - |
 | Persona 5 Royal | ✅ | - |
 | Persona 5 Tactica | ✅ | - |

--- a/games.json
+++ b/games.json
@@ -263,6 +263,12 @@
             "name": "Clair Obscur: Expedition 33",
             "package": "KeplerInteractive.Expedition33_ymj30pw7xe604",
             "handler": "coral-island"
+        },
+        // One Lonely Outpost
+        {
+            "name": "One Lonely Outpost",
+            "package": "FreedomGames.OneLonelyOutpostGame_0c9x75n11d8wg",
+            "handler": "one-lonely-outpost"
         }
     ]
 }


### PR DESCRIPTION
Lovely little game, and I've had A Week™️ (nationwide powercut on Monday, chemical plant fire today... o.o) so it's nice to just sit down with something that gets it, y'know?

The game stores the UUID for the save slot in  `globals/AccountGlobalData.json`, so you do need this file. `globals/GameSettings.json` could be skipped, but if you've changed them in one version of the game you might as well carry them over.

The game saves into `%AppData%\..\LocalLow\Freedom Games\One Lonely Outpost`. Wondering whether it's worth adding a message to the output indicating this? Could be in `games.json` as `"outpath": "%AppData%\..\LocalLow\Freedom Games\One Lonely Outpost"` or something, printed out after the zip filename. What you think?